### PR TITLE
switch from v2.0.0 to v1.10.0

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,10 +37,10 @@ jobs:
           PATCH="$(echo "$LATEST" | cut -d. -f 3)"
           NEXT="$MAJOR_MINOR.$((PATCH + 1))"
 
-          # Remove once v2.0.0 is tagged
+          # Remove once v1.10.0 is tagged
           if [ "$LATEST" = "v1.9.4" ]
           then
-            NEXT="v2.0.0"
+            NEXT="v1.10.0"
           fi
 
           # don't build if we already have built this SHA for the same patch version


### PR DESCRIPTION
We plan to make v1.10.0 the next release, due to Golang major revision "fun".

We harded to v2.0.0 in #1, instead switch nightly builds to be v1.10.0-nightlyXXXX