### PR TITLE
create release instead of pushing tag

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,8 @@ jobs:
           fetch-depth: 0
 
       - name: Build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           eval "$(ssh-agent -s)"
           ssh-add - <<< "${{ secrets.DEPLOY_KEY }}"
@@ -55,5 +57,5 @@ jobs:
           fi
 
           TAG="$NEXT-nightly$(date +%Y%m%d)"
-          git tag "$TAG"
-          git push nightly "HEAD:$BRANCH" "$TAG"
+          git push nightly "HEAD:$BRANCH"
+          gh release create --target "$BRANCH" "$TAG"


### PR DESCRIPTION
Pairs with this change to build artifacts after a release is published instead of after the tag is pushed:

- https://github.com/slackhq/nebula/pull/1572